### PR TITLE
Moved react and react-dom to peer dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,10 @@
     "emoji-regex": "^6.4.1",
     "lodash.flatten": "^4.4.0",
     "prop-types": "^15.5.8",
-    "react": ">=0.14.0",
-    "react-dom": ">=0.14.0",
     "string-replace-to-array": "^1.0.1"
+  },
+  "peerDependencies": {
+    "react": ">=0.14.0",
+    "react-dom": ">=0.14.0"    
   }
 }


### PR DESCRIPTION
Installing a second react and react dom with >=0.14 break stuff, especially now after React 16 is out. Moving them to peer dependencies prevents this.