### PR TITLE
New supports: URLs & ascii followed by normal text without space

### DIFF
--- a/src/__tests__/__snapshots__/index-test.js.snap
+++ b/src/__tests__/__snapshots__/index-test.js.snap
@@ -1219,6 +1219,12 @@ Array [
 ]
 `;
 
+exports[`toArray consecutive ascii and non char word-break 1`] = `
+Array [
+  ":)a",
+]
+`;
+
 exports[`toArray consecutive ascii and simple alias emojis without word-break 1`] = `
 Array [
   <span
@@ -1450,5 +1456,71 @@ Array [
     }>
     😃
 </span>,
+]
+`;
+
+exports[`toArray emoji and url (no space) 1`] = `
+Array [
+  ":)https://google.com",
+]
+`;
+
+exports[`toArray emoji and url (with space) 1`] = `
+Array [
+  <span
+    className={undefined}
+    style={
+        Object {
+            "height": "1em",
+            "margin": "0 .05em 0 .1em",
+            "verticalAlign": "-0.1em",
+            "width": "1em",
+          }
+    }>
+    😃
+</span>,
+  " https://google.com",
+]
+`;
+
+exports[`toArray url and emoji (no space) 1`] = `
+Array [
+  "https://google.com",
+  <span
+    className={undefined}
+    style={
+        Object {
+            "height": "1em",
+            "margin": "0 .05em 0 .1em",
+            "verticalAlign": "-0.1em",
+            "width": "1em",
+          }
+    }>
+    😃
+</span>,
+]
+`;
+
+exports[`toArray url and emoji (with space) 1`] = `
+Array [
+  "https://google.com ",
+  <span
+    className={undefined}
+    style={
+        Object {
+            "height": "1em",
+            "margin": "0 .05em 0 .1em",
+            "verticalAlign": "-0.1em",
+            "width": "1em",
+          }
+    }>
+    😃
+</span>,
+]
+`;
+
+exports[`toArray urls not parsing ascii emoji ":/" 1`] = `
+Array [
+  "https://google.com",
 ]
 `;

--- a/src/__tests__/__snapshots__/index-test.js.snap
+++ b/src/__tests__/__snapshots__/index-test.js.snap
@@ -1221,7 +1221,19 @@ Array [
 
 exports[`toArray consecutive ascii and non char word-break 1`] = `
 Array [
-  ":)a",
+  <span
+    className={undefined}
+    style={
+        Object {
+            "height": "1em",
+            "margin": "0 .05em 0 .1em",
+            "verticalAlign": "-0.1em",
+            "width": "1em",
+          }
+    }>
+    😃
+</span>,
+  "a",
 ]
 `;
 
@@ -1461,7 +1473,19 @@ Array [
 
 exports[`toArray emoji and url (no space) 1`] = `
 Array [
-  ":)https://google.com",
+  <span
+    className={undefined}
+    style={
+        Object {
+            "height": "1em",
+            "margin": "0 .05em 0 .1em",
+            "verticalAlign": "-0.1em",
+            "width": "1em",
+          }
+    }>
+    😃
+</span>,
+  "https://google.com",
 ]
 `;
 

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -169,4 +169,40 @@ describe("toArray", () => {
     );
     expect(content).toMatchSnapshot();
   });
+  test("consecutive ascii and non char word-break", () => {
+    const content = toArray(
+      ":)a"
+    );
+    expect(content).toMatchSnapshot();
+  });
+  test("urls not parsing ascii emoji \":/\"", () => {
+    const content = toArray(
+      "https://google.com"
+    );
+    expect(content).toMatchSnapshot();
+  });
+  test("url and emoji (no space)", () => {
+    const content = toArray(
+      "https://google.com:)"
+    );
+    expect(content).toMatchSnapshot();
+  });
+  test("url and emoji (with space)", () => {
+    const content = toArray(
+      "https://google.com :)"
+    );
+    expect(content).toMatchSnapshot();
+  });
+  test("emoji and url (no space)", () => {
+    const content = toArray(
+      ":)https://google.com"
+    );
+    expect(content).toMatchSnapshot();
+  });
+  test("emoji and url (with space)", () => {
+    const content = toArray(
+      ":) https://google.com"
+    );
+    expect(content).toMatchSnapshot();
+  });
 });

--- a/src/asciiRegex.js
+++ b/src/asciiRegex.js
@@ -10,15 +10,18 @@ const names = flatten(
     asciiAliases[name].map(alias => quoteRE(alias)))
 ).join("|");
 
-const firstLettersAliases = flatten(Object.keys(asciiAliases).map(name => asciiAliases[name].map(alias => quoteRE(alias.slice(0, 1))))).join("");
+const firstLettersAliases = flatten(
+  Object.keys(asciiAliases).map(name =>
+    asciiAliases[name].map(alias => quoteRE(alias.slice(0, 1))))
+).join("");
 
-const preEdgeCases = [
-  "http",
-  "https",
-].join("|");
+const preEdgeCases = ["http", "https"].join("|");
 
 // Emojis' unicode ranges from
 // https://stackoverflow.com/questions/24840667/what-is-the-regex-to-extract-all-the-emojis-from-a-string
 export default function() {
-  return new RegExp(`(${preEdgeCases})?(${names})([^\\s\\uD83C-\\uDBFF\\uDC00-\\uDFFF${firstLettersAliases}]*)`, "g");
+  return new RegExp(
+    `(${preEdgeCases})?(${names})([^\\s\\uD83C-\\uDBFF\\uDC00-\\uDFFF${firstLettersAliases}]*)`,
+    "g"
+  );
 }

--- a/src/asciiRegex.js
+++ b/src/asciiRegex.js
@@ -14,13 +14,13 @@ const edgeCases = ["http", "https"].join("|");
 
 // Regex reads as following:
 //
-// Match ascii aliases without edge cases before it.
-// Additionally, after the ascii:
+// Match ascii aliases with optional edge cases before it (to know if parsing is needed)
+// Additionally, after the ascii alias:
 //    - Forbid edge cases
-//    - Allow every kind of character that could be included in a normal alias to check later cases like :s and :smile:
+//    - Allow characters included in normal aliases (to check later cases like :s and :smile:)
 export default function() {
   return new RegExp(
-    `(${edgeCases})?(${names})(((?!(${edgeCases}))[a-z0-9_-]+):)?`,
+    `(${edgeCases})?(${names})((?!(${edgeCases}))[a-z0-9_-]+:)?`,
     "g"
   );
 }

--- a/src/asciiRegex.js
+++ b/src/asciiRegex.js
@@ -10,18 +10,17 @@ const names = flatten(
     asciiAliases[name].map(alias => quoteRE(alias)))
 ).join("|");
 
-const firstLettersAliases = flatten(
-  Object.keys(asciiAliases).map(name =>
-    asciiAliases[name].map(alias => quoteRE(alias.slice(0, 1))))
-).join("");
+const edgeCases = ["http", "https"].join("|");
 
-const preEdgeCases = ["http", "https"].join("|");
-
-// Emojis' unicode ranges from
-// https://stackoverflow.com/questions/24840667/what-is-the-regex-to-extract-all-the-emojis-from-a-string
+// Regex reads as following:
+//
+// Match ascii aliases without edge cases before it.
+// Additionally, after the ascii:
+//    - Forbid edge cases
+//    - Allow every kind of character that could be included in a normal alias to check later cases like :s and :smile:
 export default function() {
   return new RegExp(
-    `(${preEdgeCases})?(${names})([^\\s\\uD83C-\\uDBFF\\uDC00-\\uDFFF${firstLettersAliases}]*)`,
+    `(${edgeCases})?(${names})(((?!(${edgeCases}))[a-z0-9_-]+):)?`,
     "g"
   );
 }

--- a/src/asciiRegex.js
+++ b/src/asciiRegex.js
@@ -20,7 +20,7 @@ const edgeCases = ["http", "https"].join("|");
 //    - Allow characters included in normal aliases (to check later cases like :s and :smile:)
 export default function() {
   return new RegExp(
-    `(${edgeCases})?(${names})((?!(${edgeCases}))[a-z0-9_-]+:)?`,
+    `(${edgeCases})?(${names})((?!(${edgeCases}))[a-z0-9_\\-\\+]+:)?`,
     "g"
   );
 }

--- a/src/asciiRegex.js
+++ b/src/asciiRegex.js
@@ -10,8 +10,15 @@ const names = flatten(
     asciiAliases[name].map(alias => quoteRE(alias)))
 ).join("|");
 
+const firstLettersAliases = flatten(Object.keys(asciiAliases).map(name => asciiAliases[name].map(alias => quoteRE(alias.slice(0, 1))))).join("");
+
+const preEdgeCases = [
+  "http",
+  "https",
+].join("|");
+
 // Emojis' unicode ranges from
 // https://stackoverflow.com/questions/24840667/what-is-the-regex-to-extract-all-the-emojis-from-a-string
 export default function() {
-  return new RegExp(`(${names})([^\\s(${names})\\uD83C-\\uDBFF\\uDC00-\\uDFFF]*)`, "g");
+  return new RegExp(`(${preEdgeCases})?(${names})([^\\s\\uD83C-\\uDBFF\\uDC00-\\uDFFF${firstLettersAliases}]*)`, "g");
 }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -53,11 +53,14 @@ export function toArray(text, options = {}) {
     for (let i in asciiAliasKeys) {
       const alias = asciiAliasKeys[i];
       const data = asciiAliases[alias];
-      if (data.includes(match[1])) {
-        const afterAsciiAlias = match[2];
-        if(afterAsciiAlias === "") {
+      const aliasFound = match[2];
+
+      if (data.includes(aliasFound)) {
+        const isEdgeCase = match[1];
+        const afterAsciiAlias = match[3];
+        if(!isEdgeCase && afterAsciiAlias === "") {
           return `:${alias}:`;
-        }
+        } 
         // return the original word to replace its value in aliasesRegex
         return match[0]; 
       }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -58,11 +58,11 @@ export function toArray(text, options = {}) {
       if (data.includes(aliasFound)) {
         const isEdgeCase = match[1];
         const afterAsciiAlias = match[3];
-        if(!isEdgeCase && afterAsciiAlias === "") {
+        if (!isEdgeCase && afterAsciiAlias === "") {
           return `:${alias}:`;
-        } 
+        }
         // return the original word to replace its value in aliasesRegex
-        return match[0]; 
+        return match[0];
       }
     }
     return match;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -65,7 +65,6 @@ export function toArray(text, options = {}) {
         return match[0];
       }
     }
-    return match;
   }
 
   function replaceAliases(...match) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -56,9 +56,10 @@ export function toArray(text, options = {}) {
       const aliasFound = match[2];
 
       if (data.includes(aliasFound)) {
-        const isEdgeCase = match[1];
-        const afterAsciiAlias = match[3];
-        if (!isEdgeCase && afterAsciiAlias === "") {
+        const isEdgeCase = match[1] || match[5];
+        const aliasContent = match[0].slice(1, -1); // remove ":" at the beginning and end
+        const validAsciiAlias = !aliases[aliasContent];
+        if (!isEdgeCase && validAsciiAlias) {
           return `:${alias}:`;
         }
         // return the original word to replace its value in aliasesRegex

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -56,12 +56,14 @@ export function toArray(text, options = {}) {
       const aliasFound = match[2];
 
       if (data.includes(aliasFound)) {
-        const isEdgeCase = match[1] || match[5];
-        const aliasContent = match[0].slice(1, -1); // remove ":" at the beginning and end
-        const validAsciiAlias = !aliases[aliasContent];
+        const isEdgeCase = match[1];
+        const fullMatchContent = match[0].slice(1, -1); // remove ":" at the beginning and end
+        const validAsciiAlias = !aliases[fullMatchContent]; // ":" + fullMatchContent + ":" alias doesn't exist
+
         if (!isEdgeCase && validAsciiAlias) {
           return `:${alias}:`;
         }
+
         // return the original word to replace its value in aliasesRegex
         return match[0];
       }


### PR DESCRIPTION
Hello everybody !

After jumping into this URL issue (https://github.com/tommoor/react-emoji-render/issues/20) the challenge was to preserve correct emoji parsing without separators (spaces) and allow correct parsing of URLs.

As you can see in the commits, there was 2 iterations...

### First iteration

In the first 3 commits I setup urls support through a edge case selector in the regex. I took this decision because it is to be expected to have more issues like this one and solving the problem this way means we can solve other in the futures by just adding a string ! 💯 

However, while I was debugging I found out a potential bug that I introduced myself in the PR of v0.4.5 that wouldn't allow ascii + text (without space in between) to parse. It's not really a bug because the library didn't support it before v0.4.5, but it was an empty case that I didn't cover. This means strings like ":)hello" wouldn't work.

Also, I had missunderstood the behavior of `[^(...|...|...)]` because I thought each case inside the parenthesis would work as a block and it actually doesn't work like that, each char is looking for unique matches. I refactored that part to use instead the first char of each ascii alias.

At this point the post ascii alias regex was looking like this:

`([^\\s\\uD83C-\\uDBFF\\uDC00-\\uDFFF${firstLettersAliases}]*)`

I tried for 2 hours to solve the remaining issue but without any chance, so I took a step back and rethought what the regex is supposed to do:

"Parse ascii aliases that aren't part of a normal alias (e.g: `:s` and `:smile:`). If an edge case was found before the alias don't parse it".

The edge case and alias match was pretty clean and simple, however detecting if it isn't part of a bigger alias wasn't clear at all. We were using a `non (space, emoji unicode or first letter ascii alias)` logic. 

Time to refactor !

### Second iteration

The 3 last commits cover the second iteration where I rewrote the second part of the regex to be easier to understand and support the missing case. The post ascii alias regex ended up like this:

`((?!(${edgeCases}))[a-z0-9_\\-\\+]+:)?`

Cleaner right ?

The idea is to match `[a-z0-9_\\-\\+]+:` which matches with the remaining content of possible normal aliases to apply some logic of the whole matches parts later on to see if the ascii alias was part of a bigger one or not. We also don't want edge cases between the ascii alias and the rest because they might match the `[a-z0-9_\\-\\+]+:` causing bugs. The only problem of this approach is that we are hardcoding the possible characters of normal aliases (small letters, numbers, underscores, dashes and pluses). We could extract them from the aliases file dynamically but I think this is adding unnecessary complexity as normal aliases shouldn't ever have strange characters.

Finally, just to say that if you feel like the second iteration is too much a rewrite or too much coupled to the aliases content, we can merge only the first iteration 😉 

If anybody knows how to improve this PR I would be very interested in doing so !

Have a good morning, afternoon or night guys ! 🚀 