### PR TITLE
EmojiOne v4 and unicode codepoint bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ import { Emojione } from 'react-emoji-render';
 
 // or, for Emojione v4 (only png):
 <EmojioneV4 text="This ❤️ sentence includes :+1: a variety of emoji types :)" />
+// size prop can be set at 32, 64 (default) or 128
+<EmojioneV4 size={32} text="This ❤️ sentence includes :+1: a variety of emoji types :)" />
 ```
 
 ## Advanced Usage

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ import { Emojione } from 'react-emoji-render';
 
 // or, for svg images:
 <Emojione svg text="This ❤️ sentence includes :+1: a variety of emoji types :)" />
+
+// or, for Emojione v4 (only png):
+<EmojioneV4 text="This ❤️ sentence includes :+1: a variety of emoji types :)" />
 ```
 
 ## Advanced Usage

--- a/README.md
+++ b/README.md
@@ -60,9 +60,12 @@ import { Emojione } from 'react-emoji-render';
 // or, for svg images:
 <Emojione svg text="This ❤️ sentence includes :+1: a variety of emoji types :)" />
 
-// or, for Emojione v4 (only png):
+// or, for Emojione v4
 <EmojioneV4 text="This ❤️ sentence includes :+1: a variety of emoji types :)" />
-// size prop can be set at 32, 64 (default) or 128
+// note: only png supported -->
+// https://github.com/emojione/emojione-assets/issues/2
+
+// in v4 size prop can be set at 32, 64 (default) or 128
 <EmojioneV4 size={32} text="This ❤️ sentence includes :+1: a variety of emoji types :)" />
 ```
 

--- a/src/__tests__/__snapshots__/index-test.js.snap
+++ b/src/__tests__/__snapshots__/index-test.js.snap
@@ -354,6 +354,39 @@ exports[`Emoji three emoji should add onlyEmojiClassName 1`] = `
 </span>
 `;
 
+exports[`Emoji with size prop 1`] = `
+<span
+  className=""
+  size="32">
+  This 
+  <span
+    className={undefined}
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    }>
+    👨🏿
+  </span>
+   is 
+  <span
+    className={undefined}
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    }>
+    👌
+  </span>
+</span>
+`;
+
 exports[`Emoji with svg prop 1`] = `
 <span
   className=""
@@ -743,6 +776,39 @@ exports[`Emojione three emoji should add onlyEmojiClassName 1`] = `
 </span>
 `;
 
+exports[`Emojione with size prop 1`] = `
+<span
+  className=""
+  size="32">
+  This 
+  <img
+    alt="👨🏿"
+    className={undefined}
+    src="https://cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/assets/png/1f468-1f3ff.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+   is 
+  <img
+    alt="👌"
+    className={undefined}
+    src="https://cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/assets/png/1f44c.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
 exports[`Emojione with svg prop 1`] = `
 <span
   className="">
@@ -764,6 +830,427 @@ exports[`Emojione with svg prop 1`] = `
     alt="👌"
     className={undefined}
     src="https://cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/assets/svg/1f44c.svg"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
+exports[`EmojioneV4 a mixture of emoji syntax 1`] = `
+<span
+  className="">
+  <img
+    alt="😆"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f606.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+   This is a selection of 
+  <img
+    alt="💩"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f4a9.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+   emoji 
+  <img
+    alt="😃"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f603.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+   
+  <img
+    alt="👌🏿"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f44c-1f3ff.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
+exports[`EmojioneV4 aliases containing underscores 1`] = `
+<span
+  className="">
+  <img
+    alt="😜"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f61c.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+   wow
+</span>
+`;
+
+exports[`EmojioneV4 aliases with skin tone modifiers 1`] = `
+<span
+  className="">
+  Say hello to 
+  <img
+    alt="👩🏿"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f469-1f3ff.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
+exports[`EmojioneV4 ascii aliases 1`] = `
+<span
+  className="">
+  That\'s awesome 
+  <img
+    alt="😃"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f603.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
+exports[`EmojioneV4 does nothing to unknown aliases 1`] = `
+<span
+  className="">
+  An :unknown: alias
+</span>
+`;
+
+exports[`EmojioneV4 emoji with a multiple codepoints 1`] = `
+<span
+  className="">
+  Great work 
+  <img
+    alt="👍🏾"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f44d-1f3fe.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+   
+  <img
+    alt="👨‍👩‍👧‍👦"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f468-200d-1f469-200d-1f467-200d-1f466.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
+exports[`EmojioneV4 emoji with a single codepoint 1`] = `
+<span
+  className="">
+  This 
+  <img
+    alt="❤️"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/2764.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+   is 
+  <img
+    alt="👌"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f44c.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
+exports[`EmojioneV4 four emoji should not add onlyEmojiClassName 1`] = `
+<span
+  className="">
+  <img
+    alt="👋"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f44b.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+  <img
+    alt="😀"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f600.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+  <img
+    alt="👍🏾"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f44d-1f3fe.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+  <img
+    alt="💞"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f49e.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
+exports[`EmojioneV4 just emoji should add onlyEmojiClassName 1`] = `
+<span
+  className="onlyEmojiClass">
+  <img
+    alt="😀"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f600.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
+exports[`EmojioneV4 just emoticon should add onlyEmojiClassName 1`] = `
+<span
+  className="onlyEmojiClass">
+  <img
+    alt="😄"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f604.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
+exports[`EmojioneV4 simple aliases 1`] = `
+<span
+  className="">
+  This 
+  <img
+    alt="😄"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f604.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+   is nice 
+  <img
+    alt="👍"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f44d.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
+exports[`EmojioneV4 strings with no emoji 1`] = `
+<span
+  className="">
+  Just some words
+</span>
+`;
+
+exports[`EmojioneV4 three emoji should add onlyEmojiClassName 1`] = `
+<span
+  className="onlyEmojiClass">
+  <img
+    alt="😀"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f600.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+  <img
+    alt="👍🏾"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f44d-1f3fe.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+  <img
+    alt="💞"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f49e.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
+exports[`EmojioneV4 with size prop 1`] = `
+<span
+  className="">
+  This 
+  <img
+    alt="👨🏿"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/32/1f468-1f3ff.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+   is 
+  <img
+    alt="👌"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/32/1f44c.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
+exports[`EmojioneV4 with svg prop 1`] = `
+<span
+  className=""
+  svg={true}>
+  This 
+  <img
+    alt="👨🏿"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f468-1f3ff.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+   is 
+  <img
+    alt="👌"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f44c.png"
     style={
       Object {
         "height": "1em",
@@ -1120,6 +1607,39 @@ exports[`Twemoji three emoji should add onlyEmojiClassName 1`] = `
     alt="💞"
     className={undefined}
     src="https://twemoji.maxcdn.com/2/72x72/1f49e.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
+exports[`Twemoji with size prop 1`] = `
+<span
+  className=""
+  size="32">
+  This 
+  <img
+    alt="👨🏿"
+    className={undefined}
+    src="https://twemoji.maxcdn.com/2/72x72/1f468-1f3ff.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+   is 
+  <img
+    alt="👌"
+    className={undefined}
+    src="https://twemoji.maxcdn.com/2/72x72/1f44c.png"
     style={
       Object {
         "height": "1em",

--- a/src/__tests__/__snapshots__/index-test.js.snap
+++ b/src/__tests__/__snapshots__/index-test.js.snap
@@ -357,7 +357,7 @@ exports[`Emoji three emoji should add onlyEmojiClassName 1`] = `
 exports[`Emoji with size prop 1`] = `
 <span
   className=""
-  size="32">
+  size={32}>
   This 
   <span
     className={undefined}
@@ -779,7 +779,7 @@ exports[`Emojione three emoji should add onlyEmojiClassName 1`] = `
 exports[`Emojione with size prop 1`] = `
 <span
   className=""
-  size="32">
+  size={32}>
   This 
   <img
     alt="👨🏿"
@@ -1621,7 +1621,7 @@ exports[`Twemoji three emoji should add onlyEmojiClassName 1`] = `
 exports[`Twemoji with size prop 1`] = `
 <span
   className=""
-  size="32">
+  size={32}>
   This 
   <img
     alt="👨🏿"

--- a/src/__tests__/__snapshots__/index-test.js.snap
+++ b/src/__tests__/__snapshots__/index-test.js.snap
@@ -1436,7 +1436,7 @@ exports[`Twemoji composed emojis containing U+200D and U+FE0F chars 1`] = `
   <img
     alt="👩‍⚕️"
     className={undefined}
-    src="https://twemoji.maxcdn.com/2/72x72/1f469-2695.png"
+    src="https://twemoji.maxcdn.com/2/72x72/1f469-200d-2695-fe0f.png"
     style={
       Object {
         "height": "1em",
@@ -1475,7 +1475,7 @@ exports[`Twemoji emoji with a multiple codepoints 1`] = `
   <img
     alt="👨‍👩‍👧‍👦"
     className={undefined}
-    src="https://twemoji.maxcdn.com/2/72x72/1f468-1f469-1f467-1f466.png"
+    src="https://twemoji.maxcdn.com/2/72x72/1f468-200d-1f469-200d-1f467-200d-1f466.png"
     style={
       Object {
         "height": "1em",

--- a/src/__tests__/__snapshots__/index-test.js.snap
+++ b/src/__tests__/__snapshots__/index-test.js.snap
@@ -112,6 +112,24 @@ exports[`Emoji ascii aliases 1`] = `
 </span>
 `;
 
+exports[`Emoji composed emojis containing U+200D and U+FE0F chars 1`] = `
+<span
+  className="undefined">
+  <span
+    className={undefined}
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    }>
+    👩‍⚕️
+  </span>
+</span>
+`;
+
 exports[`Emoji does nothing to unknown aliases 1`] = `
 <span
   className="">
@@ -534,6 +552,24 @@ exports[`Emojione ascii aliases 1`] = `
 </span>
 `;
 
+exports[`Emojione composed emojis containing U+200D and U+FE0F chars 1`] = `
+<span
+  className="undefined">
+  <img
+    alt="👩‍⚕️"
+    className={undefined}
+    src="https://cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/assets/png/1f469-2695.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
 exports[`Emojione does nothing to unknown aliases 1`] = `
 <span
   className="">
@@ -561,7 +597,7 @@ exports[`Emojione emoji with a multiple codepoints 1`] = `
   <img
     alt="👨‍👩‍👧‍👦"
     className={undefined}
-    src="https://cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/assets/png/1f468-200d-1f469-200d-1f467-200d-1f466.png"
+    src="https://cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/assets/png/1f468-1f469-1f467-1f466.png"
     style={
       Object {
         "height": "1em",
@@ -955,6 +991,24 @@ exports[`EmojioneV4 ascii aliases 1`] = `
 </span>
 `;
 
+exports[`EmojioneV4 composed emojis containing U+200D and U+FE0F chars 1`] = `
+<span
+  className="undefined">
+  <img
+    alt="👩‍⚕️"
+    className={undefined}
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f469-2695.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
 exports[`EmojioneV4 does nothing to unknown aliases 1`] = `
 <span
   className="">
@@ -982,7 +1036,7 @@ exports[`EmojioneV4 emoji with a multiple codepoints 1`] = `
   <img
     alt="👨‍👩‍👧‍👦"
     className={undefined}
-    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f468-200d-1f469-200d-1f467-200d-1f466.png"
+    src="https://cdn.jsdelivr.net/emojione/assets/4.0/png/64/1f468-1f469-1f467-1f466.png"
     style={
       Object {
         "height": "1em",
@@ -1376,6 +1430,24 @@ exports[`Twemoji ascii aliases 1`] = `
 </span>
 `;
 
+exports[`Twemoji composed emojis containing U+200D and U+FE0F chars 1`] = `
+<span
+  className="undefined">
+  <img
+    alt="👩‍⚕️"
+    className={undefined}
+    src="https://twemoji.maxcdn.com/2/72x72/1f469-2695.png"
+    style={
+      Object {
+        "height": "1em",
+        "margin": "0 .05em 0 .1em",
+        "verticalAlign": "-0.1em",
+        "width": "1em",
+      }
+    } />
+</span>
+`;
+
 exports[`Twemoji does nothing to unknown aliases 1`] = `
 <span
   className="">
@@ -1403,7 +1475,7 @@ exports[`Twemoji emoji with a multiple codepoints 1`] = `
   <img
     alt="👨‍👩‍👧‍👦"
     className={undefined}
-    src="https://twemoji.maxcdn.com/2/72x72/1f468-200d-1f469-200d-1f467-200d-1f466.png"
+    src="https://twemoji.maxcdn.com/2/72x72/1f468-1f469-1f467-1f466.png"
     style={
       Object {
         "height": "1em",

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -1,8 +1,8 @@
 import React from "react";
-import Emoji, { Twemoji, Emojione, toArray } from "../../src/index";
+import Emoji, { Twemoji, Emojione, EmojioneV4, toArray } from "../../src/index";
 import renderer from "react-test-renderer";
 
-[Emoji, Twemoji, Emojione].forEach(Component => {
+[Emoji, Twemoji, Emojione, EmojioneV4].forEach(Component => {
   describe(Component.name, () => {
     test("strings with no emoji", () => {
       const component = renderer.create(<Component text="Just some words" />);
@@ -107,6 +107,14 @@ import renderer from "react-test-renderer";
     test("with svg prop", () => {
       const component = renderer.create(
         <Component text="This :man::skin-tone-6: is 👌" svg />
+      );
+      let tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    test("with size prop", () => {
+      const component = renderer.create(
+        <Component text="This :man::skin-tone-6: is 👌" size="32" />
       );
       let tree = component.toJSON();
       expect(tree).toMatchSnapshot();

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -115,6 +115,14 @@ import renderer from "react-test-renderer";
     test("with size prop", () => {
       const component = renderer.create(
         <Component text="This :man::skin-tone-6: is 👌" size={32} />
+        );
+      let tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    
+    test("composed emojis containing U+200D and U+FE0F chars", () => {
+      const component = renderer.create(
+        <Component text="👩‍⚕️" />
       );
       let tree = component.toJSON();
       expect(tree).toMatchSnapshot();

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -114,7 +114,7 @@ import renderer from "react-test-renderer";
 
     test("with size prop", () => {
       const component = renderer.create(
-        <Component text="This :man::skin-tone-6: is 👌" size="32" />
+        <Component text="This :man::skin-tone-6: is 👌" size={32} />
       );
       let tree = component.toJSON();
       expect(tree).toMatchSnapshot();

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,13 @@ export function Emojione({ svg, options, ...rest }) {
   return <Emoji options={options} {...rest} />;
 }
 
-export function EmojioneV4({ size = "64", options, ...rest }) {
+Emojione.propTypes = {
+  text: PropTypes.string,
+  options: PropTypes.object,
+  svg: PropTypes.bool
+};
+
+export function EmojioneV4({ size, options, ...rest }) {
   const ext = "png";
 
   options = {
@@ -60,9 +66,11 @@ export function EmojioneV4({ size = "64", options, ...rest }) {
   return <Emoji options={options} {...rest} />;
 }
 
-Emojione.propTypes = {
+EmojioneV4.propTypes = {
   text: PropTypes.string,
   options: PropTypes.object,
-  svg: PropTypes.bool,
-  size: PropTypes.oneOf(["32", "64", "128"])
+  size: PropTypes.oneOf([32, 64, 128])
+};
+EmojioneV4.defaultProps = {
+  size: 64
 };

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ export function Emojione({ svg, options, ...rest }) {
     baseUrl: `//cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/assets/${ext}/`,
     size: "",
     ext,
+    emojione: true,
     ...options
   };
 
@@ -60,6 +61,7 @@ export function EmojioneV4({ size, options, ...rest }) {
     baseUrl: `//cdn.jsdelivr.net/emojione/assets/4.0/${ext}/`,
     size,
     ext,
+    emojione: true,
     ...options
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -46,8 +46,23 @@ export function Emojione({ svg, options, ...rest }) {
   return <Emoji options={options} {...rest} />;
 }
 
+export function EmojioneV4({ size = "64", options, ...rest }) {
+  const ext = "png";
+
+  options = {
+    protocol,
+    baseUrl: `//cdn.jsdelivr.net/emojione/assets/4.0/${ext}/`,
+    size,
+    ext,
+    ...options
+  };
+
+  return <Emoji options={options} {...rest} />;
+}
+
 Emojione.propTypes = {
   text: PropTypes.string,
   options: PropTypes.object,
-  svg: PropTypes.bool
+  svg: PropTypes.bool,
+  size: PropTypes.oneOf(["32", "64", "128"])
 };

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -31,8 +31,15 @@ export function toArray(text, options = {}) {
       );
     }
 
+    let codepoint = unicodeToCodepoint(match, removeHelperCharacters);
+
+    // if Emojione we don't want to add helper characters in the URL
+    const removeHelperCharacters = options.emojione;
+    if(removeHelperCharacters) {
+      codepoint = codepoint.replace(/-200d/g, "").replace(/-fe0f/g, "");
+    }
+
     const separator = options.size ? "/" : "";
-    const codepoint = unicodeToCodepoint(match);
     const src = `${protocol}${options.baseUrl}${options.size}${separator}${codepoint}.${options.ext}`;
 
     return (

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -114,7 +114,7 @@ Emoji.propTypes = {
   onlyEmojiClassName: PropTypes.string,
   options: PropTypes.shape({
     baseUrl: PropTypes.string,
-    size: PropTypes.string,
+    size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     ext: PropTypes.string,
     className: PropTypes.string
   })

--- a/src/unicodeToCodepoint.js
+++ b/src/unicodeToCodepoint.js
@@ -2,28 +2,16 @@
 // not JIT based, and old browsers / engines
 // https://github.com/twitter/twemoji/blob/gh-pages/2/twemoji.js#L232
 const UFE0Fg = /\uFE0F/g;
-const UFE0Fstringfied = "fe0f";
 
 // \u200D is a zero-width joiner character
 // https://github.com/twitter/twemoji/blob/gh-pages/2/twemoji.js#L235
 const U200D = String.fromCharCode(0x200d);
-const U200Dstringfied = "200d";
-
-function isUrlValidCodePoint(codePointStringified) {
-  return codePointStringified !== UFE0Fstringfied &&
-    codePointStringified !== U200Dstringfied;
-}
 
 // convert utf16 into code points
 function toCodePoint(input, separator = "-") {
   const codePoints = [];
   for (let codePoint of input) {
-    const codePointStringified = codePoint.codePointAt(0).toString(16);
-
-    // We don't want to useless code points to the url
-    if (isUrlValidCodePoint(codePointStringified)) {
-      codePoints.push(codePointStringified);
-    }
+    codePoints.push(codePoint.codePointAt(0).toString(16));
   }
   return codePoints.join(separator);
 }

--- a/src/unicodeToCodepoint.js
+++ b/src/unicodeToCodepoint.js
@@ -2,16 +2,28 @@
 // not JIT based, and old browsers / engines
 // https://github.com/twitter/twemoji/blob/gh-pages/2/twemoji.js#L232
 const UFE0Fg = /\uFE0F/g;
+const UFE0Fstringfied = "fe0f";
 
 // \u200D is a zero-width joiner character
 // https://github.com/twitter/twemoji/blob/gh-pages/2/twemoji.js#L235
 const U200D = String.fromCharCode(0x200d);
+const U200Dstringfied = "200d";
+
+function isUrlValidCodePoint(codePointStringified) {
+  return codePointStringified !== UFE0Fstringfied &&
+    codePointStringified !== U200Dstringfied;
+}
 
 // convert utf16 into code points
 function toCodePoint(input, separator = "-") {
   const codePoints = [];
   for (let codePoint of input) {
-    codePoints.push(codePoint.codePointAt(0).toString(16));
+    const codePointStringified = codePoint.codePointAt(0).toString(16);
+
+    // We don't want to useless code points to the url
+    if (isUrlValidCodePoint(codePointStringified)) {
+      codePoints.push(codePointStringified);
+    }
   }
   return codePoints.join(separator);
 }


### PR DESCRIPTION
So I ended up doing everything on a single branch so we have no conflicts later (and I know @tommoor is pretty busy, so this reduces his workload).

Following up https://github.com/tommoor/react-emoji-render/issues/25 and https://github.com/tommoor/react-emoji-render/issues/26, I added EmojiOne v4 support as I explained at https://github.com/tommoor/react-emoji-render/pull/27.

That would solve the first issue but not the second one. As @wilg pointed out, `UFE0F` and `U200D` characters were being added to the emojis URLs when requested to the CDNs causing a bug where the emoji wouldn't render properly. I solved this issue and updated the tests.

closes #25 
closes #26 