### PR TITLE
fix ascii aliases and url skipping

### DIFF
--- a/src/__tests__/__snapshots__/index-test.js.snap
+++ b/src/__tests__/__snapshots__/index-test.js.snap
@@ -2099,6 +2099,50 @@ Array [
 ]
 `;
 
+exports[`toArray edge cases 1`] = `
+Array [
+  <span
+    className={undefined}
+    style={
+        Object {
+            "height": "1em",
+            "margin": "0 .05em 0 .1em",
+            "verticalAlign": "-0.1em",
+            "width": "1em",
+          }
+    }>
+    ❤️
+</span>,
+  ": :1",
+  <span
+    className={undefined}
+    style={
+        Object {
+            "height": "1em",
+            "margin": "0 .05em 0 .1em",
+            "verticalAlign": "-0.1em",
+            "width": "1em",
+          }
+    }>
+    ❤️
+</span>,
+  " ",
+  <span
+    className={undefined}
+    style={
+        Object {
+            "height": "1em",
+            "margin": "0 .05em 0 .1em",
+            "verticalAlign": "-0.1em",
+            "width": "1em",
+          }
+    }>
+    ❤️
+</span>,
+  "1:",
+]
+`;
+
 exports[`toArray emoji and url (no space) 1`] = `
 Array [
   <span
@@ -2214,7 +2258,7 @@ Array [
 ]
 `;
 
-exports[`toArray url and emoji (with space) 1`] = `
+exports[`toArray url and ascii emoji alias (with space) 1`] = `
 Array [
   "https://google.com ",
   <span
@@ -2232,7 +2276,7 @@ Array [
 ]
 `;
 
-exports[`toArray url and emoji (with space) 2`] = `
+exports[`toArray url and emoji (with space) 1`] = `
 Array [
   "https://google.com ",
   <span

--- a/src/__tests__/__snapshots__/index-test.js.snap
+++ b/src/__tests__/__snapshots__/index-test.js.snap
@@ -2023,6 +2023,24 @@ Array [
 ]
 `;
 
+exports[`toArray consecutive simple alias and ascii emojis that overlap 2`] = `
+Array [
+  <span
+    className={undefined}
+    style={
+        Object {
+            "height": "1em",
+            "margin": "0 .05em 0 .1em",
+            "verticalAlign": "-0.1em",
+            "width": "1em",
+          }
+    }>
+    ❤️
+</span>,
+  "o",
+]
+`;
+
 exports[`toArray consecutive simple alias and ascii emojis without word-break 1`] = `
 Array [
   <span
@@ -2184,6 +2202,12 @@ Array [
 ]
 `;
 
+exports[`toArray url and ascii emoji alias (no space) 1`] = `
+Array [
+  "https://google.com:)",
+]
+`;
+
 exports[`toArray url and emoji (no space) 1`] = `
 Array [
   "https://google.com",
@@ -2197,7 +2221,7 @@ Array [
             "width": "1em",
           }
     }>
-    😃
+    ❤️
 </span>,
 ]
 `;
@@ -2217,6 +2241,12 @@ Array [
     }>
     😃
 </span>,
+]
+`;
+
+exports[`toArray url including ascii emoji alias 1`] = `
+Array [
+  "https://foo:oops@example.com",
 ]
 `;
 

--- a/src/__tests__/__snapshots__/index-test.js.snap
+++ b/src/__tests__/__snapshots__/index-test.js.snap
@@ -2210,19 +2210,7 @@ Array [
 
 exports[`toArray url and emoji (no space) 1`] = `
 Array [
-  "https://google.com",
-  <span
-    className={undefined}
-    style={
-        Object {
-            "height": "1em",
-            "margin": "0 .05em 0 .1em",
-            "verticalAlign": "-0.1em",
-            "width": "1em",
-          }
-    }>
-    ❤️
-</span>,
+  "https://google.com:heart:",
 ]
 `;
 
@@ -2240,6 +2228,24 @@ Array [
           }
     }>
     😃
+</span>,
+]
+`;
+
+exports[`toArray url and emoji (with space) 2`] = `
+Array [
+  "https://google.com ",
+  <span
+    className={undefined}
+    style={
+        Object {
+            "height": "1em",
+            "margin": "0 .05em 0 .1em",
+            "verticalAlign": "-0.1em",
+            "width": "1em",
+          }
+    }>
+    ❤️
 </span>,
 ]
 `;

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -155,6 +155,10 @@ describe("toArray", () => {
     const content = toArray(":smile:)");
     expect(content).toMatchSnapshot();
   });
+  test("consecutive simple alias and ascii emojis that overlap", () => {
+    const content = toArray(":heart:o");
+    expect(content).toMatchSnapshot();
+  });
   test("consecutive simple alias and ascii emojis without word-break", () => {
     const content = toArray(":smile::)");
     expect(content).toMatchSnapshot();
@@ -175,8 +179,12 @@ describe("toArray", () => {
     const content = toArray("https://google.com");
     expect(content).toMatchSnapshot();
   });
-  test("url and emoji (no space)", () => {
+  test("url and ascii emoji alias (no space)", () => {
     const content = toArray("https://google.com:)");
+    expect(content).toMatchSnapshot();
+  });
+  test("url and emoji (no space)", () => {
+    const content = toArray("https://google.com:heart:");
     expect(content).toMatchSnapshot();
   });
   test("url and emoji (with space)", () => {
@@ -189,6 +197,10 @@ describe("toArray", () => {
   });
   test("emoji and url (with space)", () => {
     const content = toArray(":) https://google.com");
+    expect(content).toMatchSnapshot();
+  });
+  test("url including ascii emoji alias", () => {
+    const content = toArray("https://foo:oops@example.com");
     expect(content).toMatchSnapshot();
   });
   test("single letter aliases", () => {

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -191,6 +191,10 @@ describe("toArray", () => {
     const content = toArray("https://google.com :)");
     expect(content).toMatchSnapshot();
   });
+  test("url and emoji (with space)", () => {
+    const content = toArray("https://google.com :heart:");
+    expect(content).toMatchSnapshot();
+  });
   test("emoji and url (no space)", () => {
     const content = toArray(":)https://google.com");
     expect(content).toMatchSnapshot();

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -187,7 +187,7 @@ describe("toArray", () => {
     const content = toArray("https://google.com:heart:");
     expect(content).toMatchSnapshot();
   });
-  test("url and emoji (with space)", () => {
+  test("url and ascii emoji alias (with space)", () => {
     const content = toArray("https://google.com :)");
     expect(content).toMatchSnapshot();
   });
@@ -209,6 +209,10 @@ describe("toArray", () => {
   });
   test("single letter aliases", () => {
     const content = toArray(":v: :*::#: :o::x:");
+    expect(content).toMatchSnapshot();
+  });
+  test("edge cases", () => {
+    const content = toArray("<3: :1<3 <31:");
     expect(content).toMatchSnapshot();
   });
 });

--- a/src/aliasRegex.js
+++ b/src/aliasRegex.js
@@ -1,7 +1,8 @@
 export const allowedAliasCharacters = "\\w\\-\\_\\+\\*\\(\\)\\!#&åô’çéãí“”,";
+export const startOfURL = "https?\\S*";
 
 function getAliasesRegex() {
-  return new RegExp(`:([${allowedAliasCharacters}]+):`, "g");
+  return new RegExp(`(?<!${startOfURL}):([${allowedAliasCharacters}]+):`, "g");
 }
 
 export default getAliasesRegex;

--- a/src/asciiRegex.js
+++ b/src/asciiRegex.js
@@ -10,6 +10,8 @@ const names = flatten(
   })
 ).join("|");
 
+const edgeCases = [startOfURL].join("|");
+
 // Regex reads as following:
 //
 // Match ascii aliases with optional edge cases before it (to know if parsing is needed)
@@ -18,7 +20,7 @@ const names = flatten(
 //    - Allow characters included in normal aliases (to check later cases like :s and :smile:)
 export default function() {
   return new RegExp(
-    `(${startOfURL})?(${names})([${allowedAliasCharacters}]*:)?`,
+    `(${edgeCases})?(${names})([${allowedAliasCharacters}]*:)?`,
     "g"
   );
 }

--- a/src/asciiRegex.js
+++ b/src/asciiRegex.js
@@ -10,7 +10,7 @@ const names = flatten(
   })
 ).join("|");
 
-const edgeCases = ["http", "https"].join("|");
+const edgeCases = "https?\\S*";
 
 // Regex reads as following:
 //

--- a/src/asciiRegex.js
+++ b/src/asciiRegex.js
@@ -1,7 +1,7 @@
 import asciiAliases from "../data/asciiAliases";
 import flatten from "lodash.flatten";
 
-import { allowedAliasCharacters } from "./aliasRegex";
+import { allowedAliasCharacters, startOfURL } from "./aliasRegex";
 import { escapeStringToBeUsedInRegExp } from "./utils";
 
 const names = flatten(
@@ -9,8 +9,6 @@ const names = flatten(
     return asciiAliases[name].map(escapeStringToBeUsedInRegExp);
   })
 ).join("|");
-
-const edgeCases = "https?\\S*";
 
 // Regex reads as following:
 //
@@ -20,7 +18,7 @@ const edgeCases = "https?\\S*";
 //    - Allow characters included in normal aliases (to check later cases like :s and :smile:)
 export default function() {
   return new RegExp(
-    `(${edgeCases})?(${names})([${allowedAliasCharacters}]*:)?`,
+    `(${startOfURL})?(${names})([${allowedAliasCharacters}]*:)?`,
     "g"
   );
 }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -80,7 +80,7 @@ export function toArray(text, options = {}) {
         }
 
         const isMaybePartOfBiggerAlias =
-          maybeBiggerAliasCharacters !== undefined;
+          maybeBiggerAliasCharacters !== undefined && fullMatch[0] == ":";
 
         if (!isMaybePartOfBiggerAlias) {
           return `:${alias}:`; // asciiAlias transformed in alias to be replaced afterwards by aliasRegex
@@ -116,6 +116,9 @@ export function toArray(text, options = {}) {
     while (previousTextWithoutAsciiAliases !== textWithoutAsciiAliases) {
       previousTextWithoutAsciiAliases = textWithoutAsciiAliases;
       textWithoutAsciiAliases = textWithoutAsciiAliases.replace(
+        aliasesRegex,
+        replaceAliases
+      ).replace(
         asciiAliasesRegex,
         replaceAsciiAliases
       );
@@ -124,10 +127,10 @@ export function toArray(text, options = {}) {
     return textWithoutAsciiAliases;
   }
 
-  const textWithouAsciiAliases = replaceAllAsciiAliases(text);
+  const textWithoutAsciiAliases = replaceAllAsciiAliases(text);
 
   return replace(
-    textWithouAsciiAliases.replace(aliasesRegex, replaceAliases),
+    textWithoutAsciiAliases.replace(aliasesRegex, replaceAliases),
     unicodeEmojiRegex,
     replaceUnicodeEmoji
   );

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -80,20 +80,20 @@ export function toArray(text, options = {}) {
         }
 
         const isMaybePartOfBiggerAlias =
-          maybeBiggerAliasCharacters !== undefined && fullMatch[0] == ":";
+          maybeBiggerAliasCharacters !== undefined;
 
         if (!isMaybePartOfBiggerAlias) {
-          return `:${alias}:`; // asciiAlias transformed in alias to be replaced afterwards by aliasRegex
+          return aliases[alias]; // replace with unicode
+        } else if (fullMatch[0] === ":") {
+          const fullMatchContent = fullMatch.slice(1, -1); // remove ":" at the beginning and end
+          const isPartOfBiggerAlias = aliases[fullMatchContent] !== undefined; // ":" + fullMatchContent + ":" alias doesn't exist
+
+          if (isPartOfBiggerAlias) {
+            return fullMatch; // do nothing
+          }
         }
 
-        const fullMatchContent = fullMatch.slice(1, -1); // remove ":" at the beginning and end
-        const isPartOfBiggerAlias = aliases[fullMatchContent] !== undefined; // ":" + fullMatchContent + ":" alias doesn't exist
-
-        if (isPartOfBiggerAlias) {
-          return fullMatch; // do nothing
-        }
-
-        return `:${alias}:${maybeBiggerAliasCharacters}`; // also return matched characters afterwards to handle them in next iteration
+        return `${aliases[alias]}${maybeBiggerAliasCharacters}`; // also return matched characters afterwards to handle them in next iteration
       }
     }
   }
@@ -116,9 +116,6 @@ export function toArray(text, options = {}) {
     while (previousTextWithoutAsciiAliases !== textWithoutAsciiAliases) {
       previousTextWithoutAsciiAliases = textWithoutAsciiAliases;
       textWithoutAsciiAliases = textWithoutAsciiAliases.replace(
-        aliasesRegex,
-        replaceAliases
-      ).replace(
         asciiAliasesRegex,
         replaceAsciiAliases
       );
@@ -127,13 +124,11 @@ export function toArray(text, options = {}) {
     return textWithoutAsciiAliases;
   }
 
-  const textWithoutAsciiAliases = replaceAllAsciiAliases(text);
-
-  return replace(
-    textWithoutAsciiAliases.replace(aliasesRegex, replaceAliases),
-    unicodeEmojiRegex,
-    replaceUnicodeEmoji
-  );
+  let replacedText = text;
+  replacedText = replacedText.replace(aliasesRegex, replaceAliases);
+  replacedText = replaceAllAsciiAliases(replacedText);
+  replacedText = replacedText.replace(aliasesRegex, replaceAliases);
+  return replace(replacedText, unicodeEmojiRegex, replaceUnicodeEmoji);
 }
 
 export default function Emoji({


### PR DESCRIPTION
* replace full aliases before (and after) ascii aliases
  (fixes e.g. ":heart:oops")
* skip urls entirely (fixes e.g. "https://foo:oops@example.com")

fixes #54