### PR TITLE
Added default option

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -34,13 +34,13 @@ for (const alias of Object.keys(asciiAliases)) {
   }
 }
 
-export function toArray(text, options = {}) {
+export function toArray(text, isDefault, options = {}) {
   const protocol = normalizeProtocol(options.protocol);
 
   function replaceUnicodeEmoji(match, i) {
     if (!options.baseUrl) {
       return (
-        <span key={i} style={style} className={options.className}>
+        <span key={i} style={isDefault? style:{}} className={options.className}>
           {match}
         </span>
       );
@@ -62,7 +62,7 @@ export function toArray(text, options = {}) {
         key={i}
         alt={match}
         src={src}
-        style={style}
+        style={isDefault? style:{}}
         className={options.className}
         {...options.props}
       />
@@ -112,6 +112,7 @@ export default function Emoji({
   text,
   onlyEmojiClassName,
   options = {},
+  isDefault=true,
   className,
   children,
   ...rest
@@ -146,7 +147,7 @@ export default function Emoji({
   }
 
   const output = returnNonStringStrippedElements(
-    toArray(text, options),
+    toArray(text, isDefault, options),
     nonStringElements
   );
 


### PR DESCRIPTION
## Related issue
closes #115 

## Updates 
- Added isDefault to Emoji
- if isDefault is set false, the style will be empty instead of 
`{
  width: "1em",
  height: "1em",
  margin: "0 .05em 0 .1em",
  verticalAlign: "-0.1em",
}`

## Demo isDefault true and false
### Tested on React app

![isDefaul-demo](https://github.com/tommoor/react-emoji-render/assets/73622805/e58341a4-9b82-4650-8e5f-414c6c6824f7)
